### PR TITLE
Improve accessibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export const cssBaseLine = css`
   ${reset}
 
   body {
-    word-wrap: break-word;
+    overflow-wrap: break-word;
     font-family: system-ui, sans-serif;
   }
   a {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ export const cssBaseLine = css`
     overflow-wrap: break-word;
     font-family: system-ui, sans-serif;
   }
+
   a {
     color: inherit;
-    text-decoration: none;
   }
   img {
     vertical-align: middle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,15 +12,16 @@ export const cssBaseLine = css`
   a {
     color: inherit;
   }
+
   img {
     vertical-align: middle;
   }
+
   input,
   button,
   textarea {
     margin: 0;
     padding: 0;
-    outline: none;
     border: none;
     background-color: inherit;
     color: inherit;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,6 @@ import reset from 'styled-reset'
 export const cssBaseLine = css`
   ${reset}
 
-  html {
-    font-size: 62.5%;
-  }
   body {
     word-wrap: break-word;
     font-family: system-ui, sans-serif;


### PR DESCRIPTION
- make `font-size` as browser's default
- use `overflow-wrap` instead of non-standards `word-wrap` 
- link has underline decoration by default
- make appear focus indicator by default https://github.com/kufu/smarthr-normalize-css/commit/7933bb208b41be982f11acd1a41ec9c55a1cab70