### PR TITLE
feat: 入力系の要素でもフォントファミリー、サイズを継承

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ export const cssBaseLine = css`
     background-color: inherit;
     color: inherit;
   }
+
+  button,
+  input,
+  select,
+  textarea {
+    font-family: inherit;
+    font-size: 100%;
+  }
 `
 
 export const CssBaseLine = createGlobalStyle`${cssBaseLine}`


### PR DESCRIPTION
body でフォント設定をしていても入力系の要素だけ反映されませんでした。原因は以下の通りなので、設定の追加を検討していただきたいです。

[HTML フォームへのスタイル設定#フォントとテキスト - ウェブ開発を学ぶ | MDN](https://developer.mozilla.org/ja/docs/Learn/Forms/Styling_web_forms#fonts_and_text)

> デフォルトで、一部のブラウザーは親から [font-family](https://developer.mozilla.org/ja/docs/Web/CSS/font-family) や [font-size](https://developer.mozilla.org/ja/docs/Web/CSS/font-size) を継承しません。代わりに多くのブラウザーでは、システムのデフォルトの体裁を使用します。フォームの体裁を他のコンテンツと一致させるには、以下のルールをスタイルシートに追加するとよいでしょう:
> ```
> button, input, select, textarea {
>   font-family : inherit;
>   font-size : 100%;
> }
> ```