### PR TITLE
chore: yarn clean しても esm ディレクトリが残ってしまう問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:lib": "tsc -p tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.esm.build.json",
     "lint": "eslint 'src/**/*.ts{,x}'",
-    "clean": "rimraf ./lib",
+    "clean": "rimraf ./lib ./esm",
     "prepublishOnly": "run-s clean lint build",
     "release:dryrun": "standard-version --dry-run",
     "release": "standard-version"


### PR DESCRIPTION
`yarn build` すると  `lib` と `esm` ディレクトリが生成されるのですが、`yarn clean` しても `lib` しか削除されません。

この修正により `esm` も削除されるようになります。