### PR TITLE
esm ディレクトリを配布パッケージに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "git+git@github.com:kufu/smarthr-normalize-css"
   },
+  "files": [
+    "esm",
+    "lib"
+  ],
   "homepage": "https://github.com/kufu/smarthr-normalize-css#readme",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
`esm` ディレクトリが NPM パッケージの配布内容に含まれていないようです。このPRでは、`esm` ディレクトリを含められるように修正します。
