### PR TITLE
feat: body に `line-height: 1.5` を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export const cssBaseLine = css`
   body {
     overflow-wrap: break-word;
     font-family: system-ui, sans-serif;
+    line-height: 1.5;
   }
 
   a {


### PR DESCRIPTION
- [20231130_SmartHR UI 定例](https://smarthr-inc.docbase.io/posts/3205364)にて、line-heightを[smarthr-normalize-css](https://github.com/kufu/smarthr-normalize-css)で指定することを合意
<img width="850" alt="image" src="https://github.com/kufu/smarthr-normalize-css/assets/25091548/9adf9fb0-fb29-44db-b204-7e484ea73eca">

- https://github.com/kufu/smarthr-ui/pull/3616 このPRでデフォルトで指定していたline-heightを削除した。
- 当初は[利用プロダクト側のbodyでline-heightを指定する](https://kufuinc.slack.com/archives/CGC58MW01/p1701168550405059?thread_ts=1701167825.072409&cid=CGC58MW01)ことを想定していたが定例で議論を経て、smarthr-normalize-css側で指定する事になった。